### PR TITLE
Change web3 provider port from 9545 to 8545

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ app.post('/sendCoin', (req, res) => {
 app.listen(port, () => {
 
   // fallback - use your fallback strategy (local node / hosted node + in-dapp id mgmt / fail)
-  truffle_connect.web3 = new Web3(new Web3.providers.HttpProvider("http://127.0.0.1:9545"));
+  truffle_connect.web3 = new Web3(new Web3.providers.HttpProvider("http://127.0.0.1:8545"));
 
   console.log("Express Listening at http://localhost:" + port);
 


### PR DESCRIPTION
Change web3 provider port from 9545 to 8545 on `server.js` because on `truffle.js` we defined port `8545`.


